### PR TITLE
Typos and highlighting

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -14,81 +14,93 @@ Drop the `butterbean` folder into your plugin. That's the simple part.
 
 You're only going to want to load this on the edit post screen for whatever post type you're using it on.
 
-        add_action( 'load-post.php'     'th_load' );
-        add_action( 'load-post-new.php' 'th_load' );
+```php
+add_action( 'load-post.php'     'th_load' );
+add_action( 'load-post-new.php' 'th_load' );
 
-        function th_load() {
+function th_load() {
 
-        	// Bail if not our post type.
-        	if ( 'your_post_type' !== get_current_screen()->post_type )
-        		return;
+	// Bail if not our post type.
+	if ( 'your_post_type' !== get_current_screen()->post_type )
+		return;
 
-        	require_once( 'path/to/butterbean/butterbean.php' );
-        }
+	require_once( 'path/to/butterbean/butterbean.php' );
+}
+```
 
 ### Registration
 
 There's a built-in action hook called `butterbean_register`.  You're going to use that to register everything.  So, you need to set up a callback function for that.
 
-        add_action( 'butterbean_register', 'th_register', 10, 2 );
+```php
+add_action( 'butterbean_register', 'th_register', 10, 2 );
 
-        function th_register( $butterbean, $post_type ) {
+function th_register( $butterbean, $post_type ) {
 
-        	// Register managers, sections, controls, and settings here.
-        }
+	// Register managers, sections, controls, and settings here.
+}
+```
 
 #### Registering a manager
 
 A **manager** is a group of sections, controls, and settings.  It's displayed as a single meta box.  There can be multiple managers per screen (don't try multiples yet).
 
-        $butterbean->register_manager(
-        	'example',
-        	array(
-        		'label'     => esc_html__( 'Example', 'your-textdomain' ),
-        		'post_type' => 'your_post_type',
-        		'context'   => 'normal',
-        		'priority'  => 'high'
-        	)
-        );
+```php
+$butterbean->register_manager(
+	'example',
+	array(
+		'label'     => esc_html__( 'Example', 'your-textdomain' ),
+		'post_type' => 'your_post_type',
+		'context'   => 'normal',
+		'priority'  => 'high'
+	)
+);
 
-        $manager = $butterbean->get_manager( 'example' );
+$manager = $butterbean->get_manager( 'example' );
+```
 
 #### Registering a sections
 
 A **section** is a group of controls within a manager.  They are presented as "tabbed" sections in the UI.
 
-        $manager->register_section(
-        	'section_1',
-        	array(
-        		'label' => esc_html__( 'Section 1', 'your-textdomain' ),
-        		'icon'  => 'dashicons-admin-generic'
-        	)
-        );
+```php
+$manager->register_section(
+	'section_1',
+	array(
+		'label' => esc_html__( 'Section 1', 'your-textdomain' ),
+		'icon'  => 'dashicons-admin-generic'
+	)
+);
+```
 
 #### Registering a control
 
 A **control** is essentially a form field. It's the field(s) that a user enters data into.  Each control belongs to a section.  Each control should also be tied to a setting (below).
 
-        $manager->register_control(
-        	'abc_xyz', // Same as setting name.
-        	array(
-        		'type'    => 'text',
-        		'section' => 'section_1',
-        		'label'   => esc_html__( 'Control ABC', 'your-textdomain' ),
-        		'attr'    => array( 'class' => 'widefat' )
-        	)
-        );
+```php
+$manager->register_control(
+	'abc_xyz', // Same as setting name.
+	array(
+		'type'    => 'text',
+		'section' => 'section_1',
+		'label'   => esc_html__( 'Control ABC', 'your-textdomain' ),
+		'attr'    => array( 'class' => 'widefat' )
+	)
+);
+```
 
 #### Registering a setting
 
 A **setting** is nothing more than some post metadata and how it gets stored.  A setting belongs to a specific control.
 
-        $manager->register_setting(
-        	'abc_xyz', // Same as control name.
-        	array(
-        		'sanitize_callback' => 'wp_filter_nohtml_kses'
-        	)
-        );
+```php
+$manager->register_setting(
+	'abc_xyz', // Same as control name.
+	array(
+		'sanitize_callback' => 'wp_filter_nohtml_kses'
+	)
+);
+```
 
 ## Professional Support
 

--- a/readme.md
+++ b/readme.md
@@ -15,8 +15,8 @@ Drop the `butterbean` folder into your plugin. That's the simple part.
 You're only going to want to load this on the edit post screen for whatever post type you're using it on.
 
 ```php
-add_action( 'load-post.php'     'th_load' );
-add_action( 'load-post-new.php' 'th_load' );
+add_action( 'load-post.php',     'th_load' );
+add_action( 'load-post-new.php', 'th_load' );
 
 function th_load() {
 
@@ -59,7 +59,7 @@ $butterbean->register_manager(
 $manager = $butterbean->get_manager( 'example' );
 ```
 
-#### Registering a sections
+#### Registering a section
 
 A **section** is a group of controls within a manager.  They are presented as "tabbed" sections in the UI.
 


### PR DESCRIPTION
Added syntax highlighting for easier code readability.
Fixed small typo and missing commas in `add_action` call.
