### PR TITLE
Descriptions should use the same font color as other descriptive labels in WordPress core.

### DIFF
--- a/css/butterbean.css
+++ b/css/butterbean.css
@@ -204,6 +204,7 @@
 	.butterbean-manager-default .butterbean-description {
 		display       : block;
 		font-style    : italic;
+		color         : #666;
 		margin-top    : 4px;
 	}
 


### PR DESCRIPTION
Descriptive labels in WordPress core use the font color #666, butterbean should too!

See here - https://github.com/WordPress/WordPress/blob/master/wp-admin/css/common.css#L808
