### PR TITLE
Fix for SVG image type

### DIFF
--- a/js/butterbean.js
+++ b/js/butterbean.js
@@ -1039,9 +1039,17 @@ window.butterbean = window.butterbean || {};
 				// Size of image to display.
 				var size = this.model.get( 'size' );
 
+				// Initial Src of image to display
+				var src  = media.url;
+
+				// Set src based on image size selected
+				if ( ! _.isUndefined( media.sizes ) ) {
+					src = media.sizes[ size ] ? media.sizes[ size ]['url'] : media.url;
+				}
+
 				// Updates the model for the view.
 				this.model.set( {
-					src   : media.sizes[ size ] ? media.sizes[ size ]['url'] : media.url,
+					src   : src,
 					alt   : media.alt,
 					value : media.id
 				} );


### PR DESCRIPTION
As **svg** doesn't generate image sizes, so **media.sizes** was throwing error because it was undefined, and retrieving image size from undefined object was causing it to not work.

So I added additional check for that, in case media sizes are not available for image types such as svg, we can just utilize the original src url.
